### PR TITLE
feat: add support for multiple paths

### DIFF
--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -19,7 +19,9 @@ describe('init().path', () => {
     const { listMdxFiles } = await import('./utils')
     const { init } = await import('./server')
 
-    jest.mocked(listMdxFiles).mockResolvedValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+    jest
+      .mocked(listMdxFiles)
+      .mockResolvedValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
 
     expect(await init({ path: 'posts' }).paths()).toEqual([
       'posts/some-file-a',
@@ -40,7 +42,9 @@ describe('init().path', () => {
     const { listMdxFiles } = await import('./utils')
     const { init } = await import('./server')
 
-    jest.mocked(listMdxFiles).mockResolvedValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+    jest
+      .mocked(listMdxFiles)
+      .mockResolvedValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
 
     expect(await init({ path: 'posts', alias: 'some-alias' }).paths()).toEqual([
       'some-alias/some-file-a',
@@ -75,7 +79,9 @@ describe('routesAsync', () => {
   it('should return the expected routes', async () => {
     const { listMdxFiles } = await import('./utils')
     const { routesAsync } = await import('./server')
-    jest.mocked(listMdxFiles).mockResolvedValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+    jest
+      .mocked(listMdxFiles)
+      .mockResolvedValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
 
     expect(await routesAsync('./path/to/component.tsx')).toEqual([
       expect.objectContaining({
@@ -128,7 +134,7 @@ describe('routes', () => {
     const { routes } = await import('./server')
     jest
       .mocked(listMdxFilesSync)
-      .mockReturnValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+      .mockReturnValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
 
     expect(routes('./path/to/component.tsx')).toEqual([
       expect.objectContaining({
@@ -205,7 +211,7 @@ describe('loadMdx', () => {
     const url = 'https://some.domain/some-path-does-not-exist'
 
     expect(() => loadMdx(new Request(url))).rejects.toThrowError(
-      `Path "posts" is not found on "${url}" url.`
+      `Path(s) posts were not found on "${url}" url.`
     )
   })
 
@@ -254,6 +260,11 @@ describe('loadMdx', () => {
 })
 
 describe('loadAllMdx', () => {
+  beforeEach(async () => {
+    const { init } = await import('./server')
+    init({ path: 'posts' })
+  })
+
   afterEach(() => {
     jest.resetAllMocks()
   })
@@ -264,7 +275,7 @@ describe('loadAllMdx', () => {
     const files = ['posts/some-file-a.mdx', 'posts/some-file-b.mdx']
     const attrs = { some: 'value' }
 
-    jest.mocked(listMdxFiles).mockResolvedValue(files)
+    jest.mocked(listMdxFiles).mockResolvedValue([files])
     jest.mocked(getFileContent).mockResolvedValue('some content')
     jest.mocked(getMdxAttributes).mockReturnValue(attrs)
 
@@ -280,7 +291,9 @@ describe('loadAllMdx', () => {
   it('should reject when it could not read the mdx file', async () => {
     const { getFileContent, listMdxFiles } = await import('./utils')
     const { loadAllMdx } = await import('./server')
-    jest.mocked(listMdxFiles).mockResolvedValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+    jest
+      .mocked(listMdxFiles)
+      .mockResolvedValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
     jest.mocked(getFileContent).mockImplementation(() => {
       throw new Error('something went wrong')
     })
@@ -292,7 +305,9 @@ describe('loadAllMdx', () => {
     const { getFileContent, getMdxAttributes, listMdxFiles } = await import('./utils')
     const { loadAllMdx } = await import('./server')
 
-    jest.mocked(listMdxFiles).mockResolvedValue(['posts/some-file-a.mdx', 'posts/some-file-b.mdx'])
+    jest
+      .mocked(listMdxFiles)
+      .mockResolvedValue([['posts/some-file-a.mdx', 'posts/some-file-b.mdx']])
     jest.mocked(getFileContent).mockResolvedValue('some content')
     jest.mocked(getMdxAttributes).mockImplementation(() => {
       throw new Error('something went wrong while extracting mdx attributes')

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -11,48 +11,79 @@ import {
 import type { Options } from './types'
 import { getOptions, setOptions } from './options'
 
+const getAliases = (options: Options) => {
+  if ('alias' in options && options.alias) {
+    return [options.alias]
+  }
+  if ('aliases' in options && options.aliases) {
+    return options.aliases
+  }
+}
+
+const getPaths = (options: Options) =>
+  'path' in options && typeof options.path === 'string' ? [options.path] : options.paths
+
 export function init(options: Options) {
   setOptions(options)
   return {
     paths: async () => {
-      const files = await listMdxFiles(options.path || './')
+      const options = getOptions()
+      const paths = getPaths(options)
+      const aliases = getAliases(options)
+      const pathsFiles = await listMdxFiles(paths)
 
-      return Promise.all(
-        files.map(file => transformFilePathToUrlPath(file, options.path, options.alias))
-      )
+      return pathsFiles.flatMap((pathFiles, index) => {
+        return pathFiles.map(file =>
+          transformFilePathToUrlPath(file, paths[index], aliases?.[index])
+        )
+      })
     },
   }
 }
 
 export const routesAsync = async (componentPath: string) => {
   const options = getOptions()
-  const files = await listMdxFiles(options.path || './')
+  const paths = getPaths(options)
+  const aliases = getAliases(options)
+  const pathsFiles = await listMdxFiles(paths)
 
-  return files.map(file => {
-    const path = transformFilePathToUrlPath(file, options.path, options.alias)
+  return pathsFiles.flatMap((pathFiles, index) => {
+    const urlPaths = pathFiles.map(pathFile =>
+      transformFilePathToUrlPath(pathFile, paths[index], aliases?.[index])
+    )
 
-    return route(path, componentPath, {
-      id: path,
-    })
+    return urlPaths.map(urlPath =>
+      route(urlPath, componentPath, {
+        id: urlPath,
+      })
+    )
   })
 }
 
 export const routes = (componentPath: string) => {
   const options = getOptions()
-  const files = listMdxFilesSync(options.path || './')
+  const paths = getPaths(options)
+  const aliases = getAliases(options)
+  const pathsFiles = listMdxFilesSync(paths)
 
-  return files.map(file => {
-    const path = transformFilePathToUrlPath(file, options.path, options.alias)
+  return pathsFiles.flatMap((pathFiles, index) => {
+    const urlPaths = pathFiles.map(pathFile =>
+      transformFilePathToUrlPath(pathFile, paths[index], aliases?.[index])
+    )
 
-    return route(path, componentPath, {
-      id: path,
-    })
+    return urlPaths.map(urlPath =>
+      route(urlPath, componentPath, {
+        id: urlPath,
+      })
+    )
   })
 }
 
 export const loadMdx = async (request: Request) => {
   const options = getOptions()
-  const path = getFilePathBasedOnUrl(request.url, options.path, options.alias)
+  const paths = getPaths(options)
+  const aliases = getAliases(options)
+  const path = getFilePathBasedOnUrl(request.url, paths, aliases)
   const content = await getFileContent(path)
   const [mdxContent, attributes] = await Promise.all([
     compileMdx(content),
@@ -65,21 +96,34 @@ export const loadMdx = async (request: Request) => {
   }
 }
 
-export const loadAllMdx = async () => {
+export const loadAllMdx = async (filterByPaths?: string[]) => {
   const options = getOptions()
-  const files = await listMdxFiles(options.path || './')
+  const paths = getPaths(options)
+  const invalidFilters = filterByPaths?.filter(path => !paths.includes(path))
+  if ((invalidFilters?.length ?? 0) > 0) {
+    throw new Error(`${invalidFilters?.join(', ')} paths do not exist.`)
+  }
 
-  return Promise.all(
-    files.map(async path => {
-      const content = await getFileContent(path)
-      const attributes = getMdxAttributes(content)
-      const [fileName] = path.split('/').reverse()
+  const pathsFiles = await listMdxFiles(
+    paths.filter(
+      path => !filterByPaths || filterByPaths.length === 0 || filterByPaths?.includes(path)
+    )
+  )
 
-      return {
-        path,
-        slug: fileName.replace('.mdx', ''),
-        ...attributes,
-      }
+  const filesPromises = await Promise.all(
+    pathsFiles.flatMap(pathFiles => {
+      return pathFiles.map(async path => {
+        const content = await getFileContent(path)
+        const attributes = getMdxAttributes(content)
+        const [fileName] = path.split('/').reverse()
+        console.log('content ', content, 'attributes ', attributes, 'fileName ', fileName)
+        return {
+          path,
+          slug: fileName.replace('.mdx', ''),
+          ...attributes,
+        }
+      })
     })
   )
+  return filesPromises
 }

--- a/src/server/types.ts
+++ b/src/server/types.ts
@@ -4,7 +4,14 @@ type MDXContent = Awaited<ReturnType<typeof run>>['default']
 type MDXProps = Parameters<MDXContent>[0]
 export type MDXComponents = MDXProps['components']
 
-export type Options = {
-  path: string
-  alias?: string
-}
+export type Options =
+  | {
+      path: string
+      paths?: never
+      alias?: string
+    }
+  | {
+      path?: never
+      paths: string[]
+      aliases?: string[]
+    }

--- a/src/server/utils.test.ts
+++ b/src/server/utils.test.ts
@@ -32,32 +32,34 @@ describe('transformFilePathToUrlPath', () => {
 
 describe('getFilePathBasedOnUrl', () => {
   it('should return the expected file path when no alias is provided', () => {
-    expect(getFilePathBasedOnUrl('https://some.url/posts/some-slug', 'posts')).toContain(
+    expect(getFilePathBasedOnUrl('https://some.url/posts/some-slug', ['posts'])).toContain(
       'react-router-mdx/posts/some-slug.mdx'
     )
   })
 
   it('should return the expected file path when an alias is provided', () => {
     expect(
-      getFilePathBasedOnUrl('https://some.url/some-alias/some-slug', 'posts', 'some-alias')
+      getFilePathBasedOnUrl('https://some.url/some-alias/some-slug', ['posts'], ['some-alias'])
     ).toContain('react-router-mdx/posts/some-slug.mdx')
   })
 
   it('should throw an exception whrn an incorrect path is provided', () => {
     expect(() =>
-      getFilePathBasedOnUrl('https://some.url/posts/some-slug', 'some-incorrect-path')
-    ).toThrow('Path "some-incorrect-path" is not found on "https://some.url/posts/some-slug" url.')
+      getFilePathBasedOnUrl('https://some.url/posts/some-slug', ['some-incorrect-path'])
+    ).toThrow(
+      'Path(s) some-incorrect-path were not found on "https://some.url/posts/some-slug" url.'
+    )
   })
 
   it('should throw an exception whrn an incorrect alias is provided', () => {
     expect(() =>
       getFilePathBasedOnUrl(
         'https://some.url/some-alias/some-slug',
-        'posts',
-        'some-incorrect-alias'
+        ['posts'],
+        ['some-incorrect-alias']
       )
     ).toThrow(
-      'Path "some-incorrect-alias" is not found on "https://some.url/some-alias/some-slug" url.'
+      'Path(s) some-incorrect-alias were not found on "https://some.url/some-alias/some-slug" url.'
     )
   })
 })


### PR DESCRIPTION
# Context
add support for multiple paths

## Main changes
- change `init` method to support multiple paths (it accepts `{ path: string } | { paths: string[] }`)
- change `loadAllMdx` method to allow filtering by paths provided (it accepts `paths?: string[] `). By default it will load all files from all paths.