### PR TITLE
feat: allow to add custom plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,3 +153,19 @@ export default function Route() {
   )
 }
 ```
+
+## Using custom MDX plugins
+
+If you need to extend the basic features of mdx and use custom [plugins](https://mdxjs.com/docs/extending-mdx/#list-of-plugins) you will need to provide it through `options` parameter in our `loadMdx` method.
+
+For example let's say you need [remark-gfm](https://github.com/remarkjs/remark-gfm) in your project. Your route loader method will look like the following:
+
+```ts
+import { loadMdx } from 'react-router-mdx/server'
+import remarkGfm from 'remark-gfm'
+import type { Route } from "./+types/post";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  return loadMdx(request, { remarkPlugins: [remarkGfm] })
+}
+```

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -3,7 +3,7 @@ import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended"
 import { defineConfig, globalIgnores } from "eslint/config";
 
 export default defineConfig([
-  globalIgnores(["./dist/**"]),
+  globalIgnores(["./dist/**", "./node_modules/**", "./demo/**"]),
   eslintPluginPrettierRecommended,
   {
     files: ["src/**/*.ts", "src/**/*.tsx"],

--- a/src/server/mdx.test.ts
+++ b/src/server/mdx.test.ts
@@ -1,0 +1,20 @@
+import { compile } from './mdx'
+
+const removeTabs = (str: string) => str.replace(/[ ]{2}/g, '')
+
+describe('compile', () => {
+  it('should return the expected outcome when there are no attributes', async () => {
+    expect(await compile(JSON.stringify(`# this is a title`))).toContain('this is a title')
+  })
+
+  it('should return the expected outcome when there are attributes and custom components', async () => {
+    const mdx = removeTabs(`---
+          title: this is a page title
+          description: this is an amazing mdx file
+          ---
+          # this is a title
+          <ThisIsACustomComponent its='prop' />
+          `)
+    expect(await compile(mdx)).toContain('this is a title')
+  })
+})

--- a/src/server/mdx.ts
+++ b/src/server/mdx.ts
@@ -1,0 +1,24 @@
+import matter from 'gray-matter'
+import { compile as compileMdx } from '@mdx-js/mdx'
+import remarkFrontmatter from 'remark-frontmatter'
+
+type Options = Pick<
+  NonNullable<Parameters<typeof compileMdx>[1]>,
+  'recmaPlugins' | 'rehypePlugins' | 'remarkPlugins' | 'remarkRehypeOptions'
+>
+
+export const compile = async (content: string, options?: Options) => {
+  const compiled = await compileMdx(content, {
+    ...(options ?? {}),
+    outputFormat: 'function-body',
+    remarkPlugins: [remarkFrontmatter, ...(options?.remarkPlugins ?? [])],
+  })
+
+  return String(compiled)
+}
+
+export const getAttributes = (content: string) => {
+  const { data: attributes } = matter(content)
+
+  return attributes
+}

--- a/src/server/utils.test.ts
+++ b/src/server/utils.test.ts
@@ -1,7 +1,5 @@
 import { describe, expect, it } from '@jest/globals'
-import { transformFilePathToUrlPath, getFilePathBasedOnUrl, compileMdx } from './utils'
-
-const removeTabs = (str: string) => str.replace(/[ ]{2}/g, '')
+import { transformFilePathToUrlPath, getFilePathBasedOnUrl } from './utils'
 
 describe('transformFilePathToUrlPath', () => {
   it('should return the expected url path when no alias is provided', async () => {
@@ -61,22 +59,5 @@ describe('getFilePathBasedOnUrl', () => {
     ).toThrow(
       'Path(s) some-incorrect-alias were not found on "https://some.url/some-alias/some-slug" url.'
     )
-  })
-})
-
-describe('readMdxFile', () => {
-  it('should return the expected outcome when there are no attributes', async () => {
-    expect(await compileMdx(JSON.stringify(`# this is a title`))).toContain('this is a title')
-  })
-
-  it('should return the expected outcome when there are attributes and custom components', async () => {
-    const mdx = removeTabs(`---
-          title: this is a page title
-          description: this is an amazing mdx file
-          ---
-          # this is a title
-          <ThisIsACustomComponent its='prop' />
-          `)
-    expect(await compileMdx(mdx)).toContain('this is a title')
   })
 })

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -1,10 +1,7 @@
 import { readFile } from 'fs/promises'
 import { glob, globSync } from 'glob'
-import matter from 'gray-matter'
 import { resolve, join } from 'path'
 import slash from 'slash'
-import { compile } from '@mdx-js/mdx'
-import remarkFrontmatter from 'remark-frontmatter'
 
 export const listMdxFiles = (paths: string[]) => {
   const allFilesPromises = paths.map(async (path: string) => {
@@ -44,19 +41,4 @@ export const getFilePathBasedOnUrl = (url: string, paths: string[], aliases?: st
   throw new Error(`Path(s) ${finalPaths.join(', ')} were not found on "${url}" url.`)
 }
 
-export const getMdxAttributes = (content: string) => {
-  const { data: attributes } = matter(content)
-
-  return attributes
-}
-
 export const getFileContent = (path: string) => readFile(path, { encoding: 'utf-8' })
-
-export const compileMdx = async (mdxContent: string) => {
-  const compiled = await compile(mdxContent, {
-    outputFormat: 'function-body',
-    remarkPlugins: [remarkFrontmatter],
-  })
-
-  return String(compiled)
-}


### PR DESCRIPTION
A route loader where the GFM plugin is needed it will look like this:

```ts
import { loadMdx } from 'react-router-mdx/server'
import remarkGfm from 'remark-gfm'
import type { Route } from "./+types/post";

export async function loader({ request }: Route.LoaderArgs) {
  return loadMdx(request, { remarkPlugins: [remarkGfm] })
}
```