### PR TITLE
feat: expose path for downstream plugins

### DIFF
--- a/src/server/mdx.ts
+++ b/src/server/mdx.ts
@@ -5,14 +5,17 @@ import remarkFrontmatter from 'remark-frontmatter'
 type Options = Pick<
   NonNullable<Parameters<typeof compileMdx>[1]>,
   'recmaPlugins' | 'rehypePlugins' | 'remarkPlugins' | 'remarkRehypeOptions'
->
+> & { path?: string }
 
 export const compile = async (content: string, options?: Options) => {
-  const compiled = await compileMdx(content, {
-    ...(options ?? {}),
-    outputFormat: 'function-body',
-    remarkPlugins: [remarkFrontmatter, ...(options?.remarkPlugins ?? [])],
-  })
+  const compiled = await compileMdx(
+    { value: content, path: options?.path },
+    {
+      ...(options ?? {}),
+      outputFormat: 'function-body',
+      remarkPlugins: [remarkFrontmatter, ...(options?.remarkPlugins ?? [])],
+    }
+  )
 
   return String(compiled)
 }

--- a/src/server/server.test.ts
+++ b/src/server/server.test.ts
@@ -204,7 +204,9 @@ describe('loadMdx', () => {
 
     const mdx = await loadMdx(new Request(`https://some.domain/${path}`))
     expect(getFileContent).toHaveBeenCalledWith(expect.stringContaining(`${path}.mdx`))
-    expect(compile).toHaveBeenCalledWith(mdxContent, undefined)
+    expect(compile).toHaveBeenCalledWith(mdxContent, {
+      path: '/home/josh/Dev/react-router-mdx/posts/path-a.mdx',
+    })
     expect(getAttributes).toHaveBeenCalledWith(mdxContent)
     expect(mdx).toEqual({
       __raw: mdxCompiled,

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -93,7 +93,7 @@ export const loadMdx = async (request: Request, options?: Parameters<typeof comp
   const path = getFilePathBasedOnUrl(request.url, paths, aliases)
   const content = await getFileContent(path)
   const [mdxContent, attributes] = await Promise.all([
-    compile(content, options),
+    compile(content, { ...options, path }),
     getAttributes(content),
   ])
 


### PR DESCRIPTION
I need access to the source path for mdx files. There are plugins that can access the `path` value from `vfile`, but the way `react-router-mdx` compiles it doesn't pass that value.

This change allows me to do custom plugins like this that will create a relative link based on the filepath:
```js
function remarkLinkPlugin(_options) {
  return (tree, vfile) => {
    UnistUtilVisit.visit(tree, "link", node => {
      let url = node.url;
      if (url.startsWith("http") || url.startsWith("#")) {
        return;
      }
      if (!url.startsWith(".")) {
        return;
      }
      let splitHref = url.split("#");
      let path = Stdlib_Option.getOr(splitHref[0], "/");
      let hash = Stdlib_Option.getOr(Stdlib_Option.map(splitHref[1], hash => "#" + hash), "");
      console.log([
        "path",
        path
      ]);
      let filePath = Stdlib_Option.getOrThrow(vfile.history[0], `File path not found for vfile: ` + Stdlib_Option.getOr(JSON.stringify(vfile), "unknown file")).split("/").filter(part => {
        if (part.includes(".mdx")) {
          return !part.includes(".md");
        } else {
          return true;
        }
      }).join("/");
      node.url = Path.resolve(filePath, path).replace(vfile.cwd + "/markdown-pages", "").replaceAll(".mdx", "").replaceAll(".md", "") + hash;
    });
  };
}
  ```

This means that if I have a file `markdown-pages/blog/announcements/new-release.mdx' with a link `[Other Post](../general/another-post.mdx)` the link will become `/blog/general/another-post`.

By structuring links in my markdown using relative links to other markdown files I can use tools to validate that the links are correct,  such as `remark-validate-links`.